### PR TITLE
SP-1 Fixed compacting empty pool

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,9 @@
 int main(int argc, char const *argv[])
 {
 	string_pool* pool = make_string_pool(1024);
-	printf("=== Init used: %lu ===\n", pool->used);
+	printf("=== Init: %lu/%lu ===\n", get_data_size(pool), pool->used);
+	compact_pool(pool);
+	printf("=== After compacting empty pool: %lu/%lu ===\n", get_data_size(pool), pool->used);
 	string_ref* p1 = put_string_in_pool(pool, "first string");
 	string_ref* p2 = put_string_in_pool(pool, "second string");
 	string_ref* p3 = put_string_in_pool(pool, "third string");
@@ -20,11 +22,10 @@ int main(int argc, char const *argv[])
 	compact_pool(pool);
 	printf("=== After compacting pool: %lu/%lu ===\n", get_data_size(pool), pool->used);
 	dump_pool(pool);
-
 	string_ref* p6 = put_string_in_pool(pool, "sixth string");
 	string_ref* p7 = put_string_in_pool(pool, "seventh string");
 	string_ref* p8 = put_string_in_pool(pool, "eight string");
-	printf("=== After pushing more stuff ===\n");
+	printf("=== After pushing more stuff: %lu/%lu ===\n", get_data_size(pool), pool->used);
 	dump_pool(pool);
 	release_string_in_pool(pool, p5);
 	release_string_in_pool(pool, p7);
@@ -33,6 +34,14 @@ int main(int argc, char const *argv[])
 	compact_pool(pool);
 	printf("=== After compacting: %lu/%lu ===\n", get_data_size(pool), pool->used);
 	dump_pool(pool);
+	release_string_in_pool(pool, p1);
+	release_string_in_pool(pool, p3);
+	release_string_in_pool(pool, p8);
+	release_string_in_pool(pool, p6);
+	printf("=== After cleaning by hand: %lu/%lu ===\n", get_data_size(pool), pool->used);
+	dump_pool(pool);
+	compact_pool(pool);
+	printf("=== After compacting empty: %lu/%lu ===\n", get_data_size(pool), pool->used);
 	release_pool(pool);
 	return 0;
 }

--- a/pool.cpp
+++ b/pool.cpp
@@ -254,5 +254,6 @@ void compact_pool(string_pool* pool)
 		}
 		ptr += ((size_t)*ptr + end_of_str + additional_bytes);
 	}
-	pool->used = free_space_begin - pool->str;
+	if(free_space_begin != nullptr)
+		pool->used = free_space_begin - pool->str;
 }


### PR DESCRIPTION
If pool is empty free_space_begin ptr will be nullptr at the end so
number of bytes used will be in most valid cases negative and though
after casting to size_t will cause erros.